### PR TITLE
GETメソッドへのnicovideo.jpへのリダイレクトを追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 'use strict';
 const http = require('http');
 const server = http.createServer((req, res) => {
-  res.end();
+  if (req.method === 'GET') {
+    res.writeHead(302, {
+      'Location': 'https://www.nicovideo.jp/'
+    });
+    res.end();
+  }
 });
 const port = 8000;
 server.listen(port, () => {


### PR DESCRIPTION
HTTPステータスコード302を確認すると、仕様上、302が行うリダイレクトはGETまたはHEADメソッドに限定されるべき、という記述を見かけました。
https://developer.mozilla.org/ja/docs/Web/HTTP/Status/302
演習のためマージ不要